### PR TITLE
Expose parseTransactionInfoToTradeActivities

### DIFF
--- a/src/hadeswap-core/utils/getTradeActivities.ts
+++ b/src/hadeswap-core/utils/getTradeActivities.ts
@@ -111,7 +111,7 @@ const isTradeTransactionInfo = (currentTransactionInfo: web3.ParsedTransactionWi
   return currentTransactionInfo.meta?.logMessages?.find(isTradeInstructionLog) !== undefined;
 };
 
-const parseTransactionInfoToTradeActivities = async ({
+export const parseTransactionInfoToTradeActivities = async ({
   tradeTxn,
   connection,
 }: {


### PR DESCRIPTION
Hi all,

I was hoping to expose your `parseTransactionInfoToTradeActivities` function so that way I can parse additional instruction types w/o having to copy over all the logic you already have for trade activity instruction type.  Here's the instructions I was looking to parse: 
```
WithdrawLiquidityOrderVirtualFees
DepositNftToPair
InitializePair
DepositLiquidityToPair
```

Please let me know if you need any other information. Thanks